### PR TITLE
Fixed issue when PdfFile is not disposed on loading error

### DIFF
--- a/PdfiumViewer/PdfFile.cs
+++ b/PdfiumViewer/PdfFile.cs
@@ -36,7 +36,10 @@ namespace PdfiumViewer
 
             var document = NativeMethods.FPDF_LoadCustomDocument(stream, password, _id);
             if (document == IntPtr.Zero)
+            {
+                Dispose();
                 throw new PdfException((PdfError)NativeMethods.FPDF_GetLastError());
+            }
 
             LoadDocument(document);
         }


### PR DESCRIPTION
This relates to https://github.com/Bluegrams/PdfiumViewer/issues/8
If pdf is password protected, the file handle is not released when the error is thrown. This calls Dispose to release the handle so the file can be later moved or deleted