### PR TITLE
Get and throw last error before dispose.

### DIFF
--- a/PdfiumViewer/PdfFile.cs
+++ b/PdfiumViewer/PdfFile.cs
@@ -37,8 +37,14 @@ namespace PdfiumViewer
             var document = NativeMethods.FPDF_LoadCustomDocument(stream, password, _id);
             if (document == IntPtr.Zero)
             {
-                Dispose();
-                throw new PdfException((PdfError)NativeMethods.FPDF_GetLastError());
+                try
+                {
+                    throw new PdfException((PdfError)NativeMethods.FPDF_GetLastError());
+                }
+                finally
+                {
+                    Dispose();
+                }
             }
 
             LoadDocument(document);


### PR DESCRIPTION
Calling `Dispose()` before `NativeMethods.FPDF_GetLastError()` will cause the latter to always return `NativeMethods.FPDF_ERR.FPDF_ERR_SUCCESS`, which is misleading. Using a `try-finally` statement to get and throw the correct error and ensure `Dispose()` is always called.