### PR TITLE
Resolve per-page memory leak on printing.

### DIFF
--- a/PdfiumViewer/PdfPrintDocument.cs
+++ b/PdfiumViewer/PdfPrintDocument.cs
@@ -214,13 +214,12 @@ namespace PdfiumViewer
             left += (width - scaledWidth) / 2;
             top += (height - scaledHeight) / 2;
 
-            Image image = _document.Render(page,
+            using Image image = _document.Render(page,
                 AdjustDpi(e.Graphics.DpiX, scaledWidth),
                 AdjustDpi(e.Graphics.DpiY, scaledHeight),
                 e.Graphics.DpiX,
                 e.Graphics.DpiY,
                 PdfRotation.Rotate0, PdfRenderFlags.ForPrinting | PdfRenderFlags.Annotations);
-
             e.Graphics.DrawImageUnscaled(image, e.PageBounds.Location);
         }
 


### PR DESCRIPTION
Resolves issue with un-disposed Image object causing significant memory leak.

Pre-change, a 28 page test PDF required 4.1GB of RAM to print.  Post-change, it took 380MB.